### PR TITLE
Don't halt sendAudio loop if buffer is too small

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1516,19 +1516,21 @@ function DiscordClient(options) {
 					var buff;
 					try {
 						buff = streamOutput.read( 1920 );
+						
+						sequence + 10 < 65535 ? sequence += 1 : sequence = 0;
+						timestamp + 9600 < 4294967295 ? timestamp += 960 : timestamp = 0;
+						var nextTime = startTime + cnt * 20;
+						
 						if (buff && buff.length === 1920) {
-							sequence + 10 < 65535 ? sequence += 1 : sequence = 0;
-							timestamp + 9600 < 4294967295 ? timestamp += 960 : timestamp = 0;
-							
 							var encoded = opusEncoder.encode(buff, 1920);
 							var audioPacket = VoicePacket(encoded, sequence, timestamp, vChannels[channelID].ws.ssrc);
-							var nextTime = startTime + cnt * 20;
 							
 							udpClient.send(audioPacket, 0, audioPacket.length, vChannels[channelID].ws.port, vChannels[channelID].endpoint, function(err) {});
-							setTimeout(function() {
-								sendAudio(sequence, timestamp, opusEncoder, streamOutput, udpClient, vWS, cnt);
-							}, 20 + (nextTime - new Date().getTime()));
 						}
+						
+						setTimeout(function() {
+							sendAudio(sequence, timestamp, opusEncoder, streamOutput, udpClient, vWS, cnt);
+						}, 20 + (nextTime - new Date().getTime()));
 					} catch (e) {
 						console.log("Voice connection abruptly ended."); 
 					}


### PR DESCRIPTION
Before this change, if a read from the stream gave to short results or none at all, the sendAudio loop would simply stop. In most cases, this is not wanted as instead the user would just signal that the stream has ended on their own.