### PR TITLE
Fix to instant sound stopping and playing.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1592,6 +1592,7 @@ function DiscordClient(options) {
 				}
 				this.stopAudioFile = function() {
 					if (playingAF) {
+						playingAF = false;
 						streamRef.stdout.end();
 						return streamRef.kill();
 					} else {


### PR DESCRIPTION
I believe the events system does not wait until it has finished, so that the variable is set again, but instead skips ahead and your audio is called to play before this variable was set to false, causing halted audio.