### PR TITLE
Fix .simulateTyping

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -937,7 +937,7 @@ function DiscordClient(options) {
 	self.simulateTyping = function(channelID, callback) {
 		request.post({
 			headers: messageHeaders(),
-			url: "https://discordapp.com/api/channels/" + target + "/typing",
+			url: "https://discordapp.com/api/channels/" + channelID + "/typing",
 		}, function(err, res, body) {
 			if (!err) {
 				if (typeof(callback) === 'function') {


### PR DESCRIPTION
When called upon, .simulateTyping generates a ReferenceError if it's `target`, but doesn't if it's `channelID`