### PR TITLE
Handle case where response is null in checkError(res)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -389,7 +389,7 @@ function DiscordClient(options) {
 		return (response.statusCode / 100 | 0) === 2
 	}
 	function checkError(response) {
-		if (!response) return 'could not get response from server.';
+		if (!response) return null;
 		return response.statusCode + " " + response.statusMessage + "\n" + JSON.stringify(response.body);
 	}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -389,7 +389,7 @@ function DiscordClient(options) {
 		return (response.statusCode / 100 | 0) === 2
 	}
 	function checkError(response) {
-		if (!response) return null;
+		if (!response) return 'could not get response from server.';
 		return response.statusCode + " " + response.statusMessage + "\n" + JSON.stringify(response.body);
 	}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ function DiscordClient(options) {
 		console.log("No token provided, and unable to parse 'tenc'. Using login method.");
 		req('post', "https://discordapp.com/api/auth/login", {email: options.email, password: options.password}, function (err, res) {
 			if (err || !checkStatus(res)) {
-				console.log("Error POSTing login information: \n" + checkError(res, res.body));
+				console.log("Error POSTing login information: \n" + checkError(res));
 				return self.emit("disconnected");
 			}
 			getGateway(res.body.token);
@@ -65,7 +65,7 @@ function DiscordClient(options) {
 
 		req('get', "https://discordapp.com/api/gateway", function (err, res) {
 			if (err || !checkStatus(res)) {
-				console.log("Error GETing gateway list: " + checkError(res, res.body));
+				console.log("Error GETing gateway list: " + checkError(res));
 				if (explicit) console.log("Incorrect login token provided.");
 				return self.emit("disconnected");
 			}
@@ -86,7 +86,7 @@ function DiscordClient(options) {
 
 		self.internals.settings = {};
 		req('get', "https://discordapp.com/api/users/@me/settings", function(err, res) {
-			if (err || !checkStatus(res)) return console.log("Error GETing client settings: " + checkError(res, res.body));
+			if (err || !checkStatus(res)) return console.log("Error GETing client settings: " + checkError(res));
 			for (var sItem in res.body) {
 				self.internals.settings[sItem] = res.body[sItem];
 			}
@@ -388,9 +388,9 @@ function DiscordClient(options) {
 	function checkStatus(response) {
 		return (response.statusCode / 100 | 0) === 2
 	}
-	function checkError(response, body) {
+	function checkError(response) {
 		if (!response) return null;
-		return response.statusCode + " " + response.statusMessage + "\n" + JSON.stringify(body);
+		return response.statusCode + " " + response.statusMessage + "\n" + JSON.stringify(response.body);
 	}
 
 	function joinVoiceChannel(server, channel, token, session, endpoint, callback) {
@@ -1023,7 +1023,7 @@ function DiscordClient(options) {
 	};
 	self.createDMChannel = function(userID, callback) {
 		req('post', "https://discordapp.com/api/users/" + self.id + "/channels", {recipient_id: userID}, function(err, res) {
-			if (err || !checkStatus(res)) return console.log("Unable to post recipient request information: " + checkError(res, res.body));
+			if (err || !checkStatus(res)) return console.log("Unable to post recipient request information: " + checkError(res));
 			uIDToDM[res.body.recipient.id] = res.body.id;
 			return callback(res.body.id);
 		});


### PR DESCRIPTION
When doing :
```
if (err || !checkStatus(res) {
    checkError(res, res.body);
```

A null response will cause the program to crash when evaluating res.body.

To fix this, `checkError(res, res.body)` is now `checkError(res)` and the body is accessed through `res` directly in `checkError`once we made sure `res` was defined.

If `res`is not defined, we return : `could not get response from server`.