### PR TITLE
Unset game being reported in presence

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,9 +77,7 @@ function DiscordClient(options) {
 				op: 3,
 				d: {
 					idle_since: input.idle_since ? input.idle_since : null,
-					game: {
-						name: input.game ? String(input.game) : null
-					}
+					game: input.game ? { name: String(input.game) } : null
 				}
 			};
 


### PR DESCRIPTION
    bot.setPresence({
        game: null
    });

leaves a `"game": {"name": null}` field on the widget.json as opposed to the lack of it.