### PR TITLE
Only process incoming audio when listener attached

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -692,7 +692,6 @@ function DiscordClient(options) {
 		checkRS(function() {
 			var channel = typeof(channelObj) === 'object' ? channelObj.channel : channelObj;
 			var audioChannels = channelObj.stereo === false ? 1 : 2;
-			var incoming = channelObj.incoming === false ? false : true;
 			var client = vChannels[channel];
 			var Opus, opusEncoder, speakingStart, speakingEnd;
 
@@ -839,8 +838,7 @@ function DiscordClient(options) {
 					sendAudio(audioChannels, opusEncoder, stream, udpClient, vWS, 1);
 				};
 
-				if (!incoming) return;
-				udpClient.on('message', function(msg) {
+				function handleMsgEvent(msg) {
 					var header = msg.slice(0, 12),
 						nonce = new Buffer(24).fill(0),
 						audio = msg.slice(12),
@@ -862,6 +860,22 @@ function DiscordClient(options) {
 
 						self.emit('incoming', ssrc, enc.decode(decrypted));
 					} catch (e) {}
+				}
+
+				function isFinalIncomingEvListener(event) {
+					return event === 'incoming' && self.listenerCount('incoming') === 0 ? true : false
+				}
+
+				self.on('newListener', function(event) {
+					if (isFinalIncomingEvListener(event)) {
+						udpClient.on('message', handleMsgEvent);
+					}
+				});
+				
+				self.on('removeListener', function(event) {
+					if (isFinalIncomingEvListener(event)) {
+						udpClient.removeListener('message', handleMsgEvent);
+					}
 				});
 			}
 		});


### PR DESCRIPTION
Only process incoming udpClient messages when a listener is attached to the 'incoming' event of the stream. This will address a possible performance issue when an audio context is obtained from the unnecessary creation of expensive objects.

This is achieved by only attaching the message handler for the udpClient when a listener is attached to the 'incoming' event of the stream.

It is no longer necessary to manually set whether or not to handle incoming audio; thus the option to do so is therefore removed.

These changes do not make any breaking changes to the API.