### PR TITLE
Added the `Delete User Reaction` Endpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -387,7 +387,7 @@ DCP.fixMessage = function(message) {
  * @arg {String} input.reaction - Either the emoji unicode or the emoji name:id/object.
  */
 DCP.addReaction = function(input, callback) {
-	this._req('put', Endpoints.REACTIONS(input.channelID, input.messageID, stringifyEmoji(input.reaction)), function(err, res) {
+	this._req('put', Endpoints.USER_REACTIONS(input.channelID, input.messageID, stringifyEmoji(input.reaction)), function(err, res) {
 		handleResCB("Unable to add reaction", err, res, callback);
 	});
 };
@@ -412,23 +412,10 @@ DCP.getReaction = function(input, callback) {
  * @arg {Object} input
  * @arg {Snowflake} input.channelID
  * @arg {Snowflake} input.messageID
+*  @arg {Snowflake} [input.userID]
  * @arg {String} input.reaction - Either the emoji unicode or the emoji name:id/object.
  */
 DCP.removeReaction = function(input, callback) {
-	this._req('delete', Endpoints.REACTIONS(input.channelID, input.messageID, stringifyEmoji(input.reaction)), function(err, res) {
-		handleResCB("Unable to remove reaction", err, res, callback);
-	});
-};
-
-/**
- * Remove another user's emoji reaction from a message.
- * @arg {Object} input
- * @arg {Snowflake} input.channelID
- * @arg {Snowflake} input.messageID
- * @arg {Snowflake} input.userID
- * @arg {String} input.reaction - Either the emoji unicode or the emoji name:id/object.
- */
-DCP.removeUserReaction = function(input, callback) {
 	this._req('delete', Endpoints.USER_REACTIONS(input.channelID, input.messageID, stringifyEmoji(input.reaction), input.userID), function(err, res) {
 		handleResCB("Unable to remove reaction", err, res, callback);
 	});
@@ -2700,12 +2687,9 @@ function Websocket(url, opts) {
 		MESSAGE_REACTIONS: function(channelID, messageID, reaction) {
 			return  this.MESSAGES(channelID, messageID) + "/reactions/" + reaction;
 		},
-		REACTIONS: function(channelID, messageID, reaction) {
-			return  this.MESSAGE_REACTIONS(channelID, messageID, reaction) + "/@me";
-		},
 		USER_REACTIONS: function(channelID, messageID, reaction, userID) {
-			return  this.MESSAGE_REACTIONS(channelID, messageID, reaction) + "/" + userID;
-		},
+		  	return  this.MESSAGE_REACTIONS(channelID, messageID, reaction) + '/' + ( (!userID || userID === this.id) ? '@me' : userID );
+		}
 
 		INVITES: function(inviteCode) {
 			return  API + "/invite/" + inviteCode;

--- a/lib/index.js
+++ b/lib/index.js
@@ -420,6 +420,20 @@ DCP.removeReaction = function(input, callback) {
 	});
 };
 
+/**
+ * Remove another user's emoji reaction from a message.
+ * @arg {Object} input
+ * @arg {Snowflake} input.channelID
+ * @arg {Snowflake} input.messageID
+ * @arg {Snowflake} input.userID
+ * @arg {String} input.reaction - Either the emoji unicode or the emoji name:id/object.
+ */
+DCP.removeUserReaction = function(input, callback) {
+	this._req('delete', Endpoints.USER_REACTIONS(input.channelID, input.messageID, stringifyEmoji(input.reaction), input.userID), function(err, res) {
+		handleResCB("Unable to remove reaction", err, res, callback);
+	});
+};
+
 /* - DiscordClient - Methods - Server Management - */
 
 /**
@@ -2688,6 +2702,9 @@ function Websocket(url, opts) {
 		},
 		REACTIONS: function(channelID, messageID, reaction) {
 			return  this.MESSAGE_REACTIONS(channelID, messageID, reaction) + "/@me";
+		},
+		USER_REACTIONS: function(channelID, messageID, reaction, userID) {
+			return  this.MESSAGE_REACTIONS(channelID, messageID, reaction) + "/" + userID;
 		},
 
 		INVITES: function(inviteCode) {


### PR DESCRIPTION
Added the Delete User Reaction endpoint to allow bots with the MANAGE_MESSAGES permission to delete another user's reaction.