### PR TITLE
Added the final reaction endpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -433,6 +433,18 @@ DCP.removeReaction = function(input, callback) {
 	});
 };
 
+/**
+ * Remove all emoji reactions from a message.
+ * @arg {Object} input
+ * @arg {Snowflake} input.channelID
+ * @arg {Snowflake} input.messageID
+ */
+DCP.removeAllReactions = function(input, callback) {
+	this._req('delete', Endpoints.MESSAGE_REACTIONS(input.channelID, input.messageID), function(err, res) {
+		handleResCB("Unable to remove reactions", err, res, callback);
+	});
+};
+
 /* - DiscordClient - Methods - Server Management - */
 
 /**
@@ -2048,7 +2060,7 @@ function handlevWSClose(voiceSession) {
 		if (member.decoder) member.decoder.destroy();
 	});
 
-	//Clear intervals and remove listeners	
+	//Clear intervals and remove listeners
 	clearInterval(voiceSession.wsKeepAlive);
 	clearInterval(voiceSession.udpKeepAlive);
 	//TODO: Emit ServerID and Channel ID. For v3
@@ -2729,7 +2741,7 @@ function Websocket(url, opts) {
 		},
 
 		MESSAGE_REACTIONS: function(channelID, messageID, reaction) {
-			return  this.MESSAGES(channelID, messageID) + "/reactions/" + reaction;
+			return  this.MESSAGES(channelID, messageID) + "/reactions" + ( !reaction ? "" : ("/" + reaction) );
 		},
 		USER_REACTIONS: function(channelID, messageID, reaction, userID) {
 		  	return  this.MESSAGE_REACTIONS(channelID, messageID, reaction) + '/' + ( (!userID || userID === this.id) ? '@me' : userID );

--- a/lib/index.js
+++ b/lib/index.js
@@ -2741,7 +2741,7 @@ function Websocket(url, opts) {
 		},
 
 		MESSAGE_REACTIONS: function(channelID, messageID, reaction) {
-			return  this.MESSAGES(channelID, messageID) + "/reactions" + ( !reaction ? "" : ("/" + reaction) );
+			return  this.MESSAGES(channelID, messageID) + "/reactions" + ( reaction ? ("/" + reaction) : "" );
 		},
 		USER_REACTIONS: function(channelID, messageID, reaction, userID) {
 		  	return  this.MESSAGE_REACTIONS(channelID, messageID, reaction) + '/' + ( (!userID || userID === this.id) ? '@me' : userID );


### PR DESCRIPTION
Added the "Delete all reactions" endpoint, which allows you to delete all reactions off of a message using the messageID and channelID. 
(already PR'd #129 but re-created and PR'd because of new commits that occurred in the duration of the PR as well as to abide by some requested changes)