### PR TITLE
Update documentation link to direct GitBook Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A small, single-file, fully featured [Discordapp](https://discordapp.com) librar
 ### Installation
 `npm install discord.io`
 
-### [Documentation / Gitbooks](https://www.gitbook.com/book/izy521/discord-io/details)
+### [Documentation / Gitbooks](https://izy521.gitbooks.io/discord-io/content/)
 
 ### Example
 ```javascript


### PR DESCRIPTION
It is not intuitive to click the "Read" button in the overview Gitbooks page, this changes the link to be direct to the documentation.