### PR TITLE
Fixed crash on certain VOICE_STATE_UPDATE events.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1971,7 +1971,7 @@ function joinVoiceChannel(client, voiceSession) {
 }
 
 function leaveVoiceChannel(client, channelID, callback) {
-	if (!client._vChannels[channelID]) return;
+	if (!channelID || !client._vChannels[channelID]) return;
 
 	try {
 		client._vChannels[channelID].ws.connection.close();


### PR DESCRIPTION
Fixes an edge case where the lib tried to leave a voice channel it didn't know it was in, usually when it's kicked due to inactivity after a restart.