### PR TITLE
Minor fix in the typings to allow Client#uploadFile to accept a Buffer as the parameter to `file`, as per the documentation.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -128,7 +128,7 @@ declare type sendMessageOpts = {
 
 declare type uploadFileOpts = {
   to: string,
-  file: string,
+  file: string|Buffer,
   filename?: string,
   message?: string
 }


### PR DESCRIPTION
Updated the type `uploadFileOpts` to allow `file` to be of type `Buffer`