### PR TITLE
Added client.muteSelf, client.unmuteSelf, client.deafenSelf and client.undeafenSelf

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1900,7 +1900,7 @@ function handleWSMessage(data, flags) {
 			channelID = _data.channel_id;
 			userID = _data.user_id;
 			server = client.servers[serverID];
-      mute = !!_data.mute;
+			mute = !!_data.mute;
 			self_mute = !!_data.self_mute;
 			deaf = !!_data.deaf;
 			self_deaf = !!_data.self_deaf;
@@ -1909,8 +1909,8 @@ function handleWSMessage(data, flags) {
 				currentVCID = server.members[userID].voice_channel_id;
 				if (currentVCID) delete( server.channels[currentVCID].members[userID] );
 				if (channelID) server.channels[channelID].members[userID] = _data;
-				mute || self_mute ? server.members[userID].mute = true : server.members[userID].mute = false;
-				deaf || self_deaf ? server.members[userID].deaf = true : server.members[userID].deaf = false;
+				server.members[userID].mute = (mute || self_mute);
+				server.members[userID].deaf = (deaf || self_deaf);
 				server.members[userID].voice_channel_id = channelID;
 			} catch(e) {}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1898,8 +1898,8 @@ function handleWSMessage(data, flags) {
 			channelID = _data.channel_id;
 			userID = _data.user_id;
 			server = client.servers[serverID];
-			self_mute = server.self_mute = !!_data.self_mute;
-			self_deaf = server.self_deaf = !!_data.self_deaf;
+			self_mute = !!_data.self_mute;
+			self_deaf = !!_data.self_deaf;
 
 			try {
 				currentVCID = server.members[userID].voice_channel_id;
@@ -1909,6 +1909,8 @@ function handleWSMessage(data, flags) {
 			} catch(e) {}
 
 			if (userID === client.id) {
+				server.self_mute = self_mute;
+				server.self_deaf = self_deaf;
 				if (channelID === null) {
 					if (server.voiceSession) leaveVoiceChannel(client, server.voiceSession.channelID);
 					return void(server.voiceSession = null);

--- a/lib/index.js
+++ b/lib/index.js
@@ -536,7 +536,7 @@ DCP.unmute = function(input, callback) {
 };
 
 /**
- * Server-deafan a user.
+ * Server-deafen a user.
  * @arg {Object} input
  * @arg {Snowflake} input.serverID
  * @arg {Snowflake} input.userID
@@ -548,7 +548,7 @@ DCP.deafen = function(input, callback) {
 };
 
 /**
- * Remove the server-deafan from a user.
+ * Remove the server-deafen from a user.
  * @arg {Object} input
  * @arg {Snowflake} input.serverID
  * @arg {Snowflake} input.userID
@@ -557,6 +557,82 @@ DCP.undeafen = function(input, callback) {
 	this._req('patch', Endpoints.MEMBERS(input.serverID, input.userID), {deaf: false}, function(err, res) {
 		handleResCB("Could not undeafen user", err, res, callback);
 	});
+};
+
+/**
+ * Self-mute the client from speaking in all voice channels.
+ * @arg {Snowflake} serverID
+ */
+DCP.muteSelf = function(serverID, callback) {
+	var server = this.servers[serverID], channelID, voiceSession;
+	if (!server) return handleErrCB(("Cannot find the server provided: " + serverID), callback);
+	
+	server.self_mute = true;
+	
+	if (!server.voiceSession) return call(callback, [null, true]);
+	
+	voiceSession = server.voiceSession;
+	voiceSession.self_mute = true;
+	channelID = voiceSession.channelID;
+	if (!channelID) return call(callback, [null, true]);
+	return call(callback, [send(this._ws, Payloads.UPDATE_VOICE(serverID, channelID, true, server.self_deaf)), true]);
+};
+
+/**
+ * Remove the self-mute from the client.
+ * @arg {Snowflake} serverID
+ */
+DCP.unmuteSelf = function(serverID, callback) {
+	var server = this.servers[serverID], channelID, voiceSession;
+	if (!server) return handleErrCB(("Cannot find the server provided: " + serverID), callback);
+	
+	server.self_mute = false;
+	
+	if (!server.voiceSession) return call(callback, [null, true]);
+	
+	voiceSession = server.voiceSession;
+	voiceSession.self_mute = false;
+	channelID = voiceSession.channelID;
+	if (!channelID) return call(callback, [null, true]);
+	return call(callback, [send(this._ws, Payloads.UPDATE_VOICE(serverID, channelID, false, server.self_deaf)), true]);
+};
+
+/**
+ * Self-deafen the client.
+ * @arg {Snowflake} serverID
+ */
+DCP.deafenSelf = function(serverID, callback) {
+	var server = this.servers[serverID], channelID, voiceSession;
+	if (!server) return handleErrCB(("Cannot find the server provided: " + serverID), callback);
+	
+	server.self_deaf = true;
+	
+	if (!server.voiceSession) return call(callback, [null, true]);
+	
+	voiceSession = server.voiceSession;
+	voiceSession.self_deaf = true;
+	channelID = voiceSession.channelID;
+	if (!channelID) return call(callback, [null, true]);
+	return call(callback, [send(this._ws, Payloads.UPDATE_VOICE(serverID, channelID, server.self_mute, true)), true]);
+};
+
+/**
+ * Remove the self-deafen from the client.
+ * @arg {Snowflake} serverID
+ */
+DCP.undeafenSelf = function(serverID, callback) {
+	var server = this.servers[serverID], channelID, voiceSession;
+	if (!server) return handleErrCB(("Cannot find the server provided: " + serverID), callback);
+	
+	server.self_deaf = false;
+	
+	if (!server.voiceSession) return call(callback, [null, true]);
+	
+	voiceSession = server.voiceSession;
+	voiceSession.self_deaf = false;
+	channelID = voiceSession.channelID;
+	if (!channelID) return call(callback, [null, true]);
+	return call(callback, [send(this._ws, Payloads.UPDATE_VOICE(serverID, channelID, server.self_mute, false)), true]);
 };
 
 /*Bot server management actions*/
@@ -1229,8 +1305,10 @@ DCP.joinVoiceChannel = function(channelID, callback) {
 	if (this._vChannels[channelID]) return handleErrCB(("Voice channel already active: " + channelID), callback);
 
 	voiceSession = getVoiceSession(this, channelID, server);
+	voiceSession.self_mute = server.self_mute;
+	voiceSession.self_deaf = server.self_deaf;
 	checkVoiceReady(voiceSession, callback);
-	return send(this._ws, Payloads.UPDATE_VOICE(serverID, channelID));
+	return send(this._ws, Payloads.UPDATE_VOICE(serverID, channelID, server.self_mute, server.self_deaf));
 };
 
 /**
@@ -1652,7 +1730,8 @@ function handleWSMessage(data, flags) {
 	var message = decompressWSMessage(data, flags);
 	var _data = message.d;
 	var client = this, user, server, member, old,
-	userID, serverID, channelID, currentVCID;
+	userID, serverID, channelID, currentVCID,
+	self_mute, self_deaf;
 	client.internals.sequence = message.s;
 
 	switch (message.op) {
@@ -1819,6 +1898,8 @@ function handleWSMessage(data, flags) {
 			channelID = _data.channel_id;
 			userID = _data.user_id;
 			server = client.servers[serverID];
+			self_mute = server.self_mute = !!_data.self_mute;
+			self_deaf = server.self_deaf = !!_data.self_deaf;
 
 			try {
 				currentVCID = server.members[userID].voice_channel_id;
@@ -1841,6 +1922,8 @@ function handleWSMessage(data, flags) {
 				}
 
 				server.voiceSession.session = _data.session_id;
+				server.voiceSession.self_mute = self_mute;
+				server.voiceSession.self_deaf = self_deaf;
 			}
 			break;
 		case "VOICE_SERVER_UPDATE":
@@ -1952,7 +2035,7 @@ function leaveVoiceChannel(client, channelID, callback) {
 		client._vChannels[channelID].udp.connection.close();
 	} catch(e) {}
 
-	send(client._ws, Payloads.UPDATE_VOICE(client.channels[channelID].guild_id, null));
+	send(client._ws, Payloads.UPDATE_VOICE(client.channels[channelID].guild_id, null, false, false));
 
 	return call(callback, [null]);
 }
@@ -1979,7 +2062,9 @@ function getVoiceSession(client, channelID, server) {
 			channelID: channelID,
 			token: null,
 			session: null,
-			endpoint: null
+			endpoint: null,
+			self_mute: false,
+			self_deaf: false
 		};
 }
 
@@ -2256,6 +2341,7 @@ function prepareAudioOld(ACBI, readableStream) {
 function sendAudio(ACBI, buffer) {
 	ACBI._sequence  = (ACBI._sequence  + 1  ) < 0xFFFF     ? ACBI._sequence  + 1   : 0;
 	ACBI._timestamp = (ACBI._timestamp + 960) < 0xFFFFFFFF ? ACBI._timestamp + 960 : 0;
+	if (ACBI._voiceSession.self_mute) return;
 	var audioPacket = AudioCB.VoicePacket(buffer, ACBI._voiceSession.ws.ssrc, ACBI._sequence, ACBI._timestamp, ACBI._secretKey);
 
 	try {
@@ -2266,7 +2352,7 @@ function sendAudio(ACBI, buffer) {
 
 function handleIncomingAudio(msg) {
 	//The response from the UDP keep alive ping
-	if (msg.length === 8) return;
+	if (msg.length === 8 || this._voiceSession.self_deaf) return;
 
 	var header = msg.slice(0, 12),
 		audio = msg.slice(12),
@@ -2373,6 +2459,8 @@ function Server(client, data) {
 	copyKeys(data, this);
 	this.large = this.large || this.member_count > LARGE_THRESHOLD;
 	this.voiceSession = null;
+	this.self_mute = !!this.self_mute;
+	this.self_deaf = !!this.self_deaf;
 	if (data.unavailable) return;
 
 	//Objects so we can use direct property accessing without for loops
@@ -2836,14 +2924,14 @@ function Websocket(url, opts) {
 				}
 			};
 		},
-		UPDATE_VOICE: function(serverID, channelID) {
+		UPDATE_VOICE: function(serverID, channelID, self_mute, self_deaf) {
 			return {
 				op: 4,
 				d: {
 					guild_id: serverID,
 					channel_id: channelID,
-					self_mute: false,
-					self_deaf: false
+					self_mute: self_mute,
+					self_deaf: self_deaf
 				}
 			};
 		},


### PR DESCRIPTION
These methods differ from using client.mute, client.deafen, etc. on your own userID in that they use the self_mute and self_deafen properties in the voice state object, so you don't need server permissions to use these functions. In addition, since Discord doesn't actually do anything different whether or not you've set self_mute and self_deaf to true or false, using muteSelf will prevent the udp connection from sending voice packets (this is undone with unmuteSelf) and deafenSelf will prevent incoming voice packets from being parsed (this is undone with undeafenSelf)

Also, fixed a typo for the comments for client.deafen and client.undeafen where "deafen" was spelled "deafan" :P 