### PR TITLE
This should fix the bug with setting the type to zero explicitly.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2829,7 +2829,7 @@ function Websocket(url, opts) {
 					game: type(input.game) === 'object' ?
 						{
 							name: input.game.name ? String(input.game.name) : null,
-							type: input.game.type ? Number(input.game.type) : 0,
+							type: type(input.game.type) === 'number' ? Number(input.game.type) : 0,
 							url: input.game.url ? String(input.game.url) : null
 						} :
 						null


### PR DESCRIPTION
With the ternary, when `input.game.type` was 0, it will go to the else of the ternary because it considered the condition to be false.