### PR TITLE
Fix bug in uploadFile when Buffer is passed.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -192,7 +192,7 @@ DCP.uploadFile = function(input, callback) {
 	if (!isBuffer && !isString) return handleErrCB("uploadFile requires a String or Buffer as the 'file' value", callback);
 	if (isBuffer) {
 		if (!input.filename) return handleErrCB("uploadFile requires a 'filename' value to be set if using a Buffer", callback);
-		file = input.filename;
+		file = input.file;
 	}
 	if (isString) try { file = FS.readFileSync(input.file); } catch(e) { return handleErrCB("File does not exist: " + input.file, callback); }
 


### PR DESCRIPTION
Setting file to input.filename just results in the bot sending the filename as the contents of the file, rather than sending the contents of the buffer. Should be input.file, in which case the buffer data is actually sent.