### PR TITLE
Fixed client.internals.sequence sometimes becoming null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1734,7 +1734,7 @@ function handleWSMessage(data, flags) {
 	var client = this, user, server, member, old,
 	userID, serverID, channelID, currentVCID,
 	mute, deaf, self_mute, self_deaf;
-	if (message.s) client.internals.sequence = message.s;
+	if (typeof message.s !== "undefined") client.internals.sequence = message.s;
 
 	switch (message.op) {
 		case 9:
@@ -1746,7 +1746,7 @@ function handleWSMessage(data, flags) {
 			break;
 		case 10:
 			//Start keep-alive interval
-			//Disconnect the client if no ping has been received
+q			//Disconnect the client if no ping has been received
 			//in 15 seconds (I think that's a decent duration)
 			//Since v3 you the IDENTIFY/RESUME payload here.
 			identifyOrResume(client);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1746,7 +1746,7 @@ function handleWSMessage(data, flags) {
 			break;
 		case 10:
 			//Start keep-alive interval
-q			//Disconnect the client if no ping has been received
+			//Disconnect the client if no ping has been received
 			//in 15 seconds (I think that's a decent duration)
 			//Since v3 you the IDENTIFY/RESUME payload here.
 			identifyOrResume(client);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1734,7 +1734,7 @@ function handleWSMessage(data, flags) {
 	var client = this, user, server, member, old,
 	userID, serverID, channelID, currentVCID,
 	mute, deaf, self_mute, self_deaf;
-	client.internals.sequence = message.s;
+	if (message.s) client.internals.sequence = message.s;
 
 	switch (message.op) {
 		case 9:

--- a/lib/index.js
+++ b/lib/index.js
@@ -1734,7 +1734,7 @@ function handleWSMessage(data, flags) {
 	var client = this, user, server, member, old,
 	userID, serverID, channelID, currentVCID,
 	mute, deaf, self_mute, self_deaf;
-	if (typeof message.s !== "undefined") client.internals.sequence = message.s;
+	if (typeof message.s === "number") client.internals.sequence = message.s;
 
 	switch (message.op) {
 		case 9:

--- a/lib/index.js
+++ b/lib/index.js
@@ -1734,9 +1734,12 @@ function handleWSMessage(data, flags) {
 	var client = this, user, server, member, old,
 	userID, serverID, channelID, currentVCID,
 	mute, deaf, self_mute, self_deaf;
-	if (typeof message.s === "number") client.internals.sequence = message.s;
 
 	switch (message.op) {
+		case 0:
+			//Event dispatched - update our sequence number
+			client.internals.sequence = message.s;
+			break;
 		case 9:
 			//Disconnect after a Invalid Session
 			//Disconnect the client if the client has received an invalid session id


### PR DESCRIPTION
Disclaimer: This is speculation

I suspect that if not every message from Discord comes with a sequence number, client.internals.sequence can potentially become undefined when receiving such a sequenceless message, and if they were to disconnect and attempt to resume at that moment, they would be attempting to resume but wouldn't have a sequence number to resume with, which may cause Discord to send an OP 9 message because the resume failed.

This PR would fix that if that's the case, but would have no effect if that isn't the issue.