### PR TITLE
Discriminator is declared as number but is string according to API

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -413,7 +413,7 @@ declare namespace Discord {
   export class User extends Resource {
     username: string;
     id: string;
-    discriminator: number;
+    discriminator: string;
     avatar: string;
     bot: boolean;
     game: Object;
@@ -444,7 +444,7 @@ declare namespace Discord {
     id: string;
     username: string;
     email: string;
-    discriminator: number;
+    discriminator: string;
     avatar: string;
     bot: boolean;
     verified: boolean;


### PR DESCRIPTION
Changed the `typings/index.d.ts` to match [User Object](https://discordapp.com/developers/docs/resources/user#user-object) API, where discriminator is a string.